### PR TITLE
fix: polling time to 15 seconds

### DIFF
--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -16,6 +16,7 @@ export default createConfig({
     baseSepolia: {
       chainId: 84532,
       transport: http(keys.ALCHEMY_URL_BASE_SEPOLIA),
+      pollingInterval: 15000 // 15 seconds
     },
   },
   contracts: {


### PR DESCRIPTION
This is a fix because the current polling interval is 1s, and ORP is falling because Alchemy, our web3 provider, declines some requests because our free plan doesn't allow that number of requests 